### PR TITLE
Allow to type falsy answers

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -23,4 +23,5 @@ before_script:
   - if [ "$dependencies" = "lowest" ]; then travis_retry composer update --prefer-lowest --prefer-stable -n; fi;
 
 script:
+  - vendor/bin/phpspec run
   - vendor/bin/behat -fprogress

--- a/composer.json
+++ b/composer.json
@@ -35,6 +35,7 @@
     "bin/companienv"
   ],
   "require-dev": {
-    "behat/behat": "^3.4"
+    "behat/behat": "^3.4",
+    "phpspec/phpspec": "^4.3"
   }
 }

--- a/spec/Companienv/IO/InputOutputInteractionSpec.php
+++ b/spec/Companienv/IO/InputOutputInteractionSpec.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace spec\Companienv\IO;
+
+use Companienv\IO\InputOutputInteraction;
+use PhpSpec\ObjectBehavior;
+use Prophecy\Argument;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+
+class InputOutputInteractionSpec extends ObjectBehavior
+{
+    function let(InputInterface $input, OutputInterface $output)
+    {
+        $this->beConstructedWith($input, $output);
+    }
+
+    function it_will_return_the_default_value()
+    {
+        $this->ask('VALUE ?', 'true')->shouldReturn('true');
+    }
+
+    function it_will_return_the_default_value_even_if_it_looks_falsy()
+    {
+        $this->ask('COUNT ?', '0')->shouldReturn('0');
+    }
+}

--- a/src/Companienv/IO/InputOutputInteraction.php
+++ b/src/Companienv/IO/InputOutputInteraction.php
@@ -27,7 +27,7 @@ class InputOutputInteraction implements Interaction
     {
         $answer = (new QuestionHelper())->ask($this->input, $this->output, new Question($question, $default));
 
-        if (!$answer) {
+        if (null === $answer || ('' === $answer && $default !== null)) {
             return $this->ask($question, $default);
         }
 


### PR DESCRIPTION
Because something like `0` is definitely a valid answer.