### PR TITLE
Autofill the.env file with the "composer --no-interaction" command

### DIFF
--- a/src/Companienv/Composer/InteractionViaComposer.php
+++ b/src/Companienv/Composer/InteractionViaComposer.php
@@ -16,11 +16,23 @@ class InteractionViaComposer implements Interaction
 
     public function askConfirmation(string $question): bool
     {
+        if (!$this->io->isInteractive()) {
+            $this->writeln('Automatically confirmed in non-interactive mode');
+
+            return true;
+        }
+
         return $this->io->askConfirmation($question);
     }
 
     public function ask(string $question, string $default = null): string
     {
+        if (!$this->io->isInteractive()) {
+            $this->writeln(sprintf('Automatically returned "%s" in non-interactive mode', $default));
+
+            return $default;
+        }
+
         return $this->io->ask($question, $default);
     }
 


### PR DESCRIPTION
Currently, our production is runned without a .env.  
All is in the current environment variables.

So in production mode, we do not want to run want to answer to questions, just copy it.

This is an example of the result:
```bash
▶ composer install --no-interaction
Loading composer repositories with package information
Installing dependencies (including require-dev) from lock file
Nothing to install or update

> Companienv\Composer\ScriptHandler::run
It looks like you are missing some configuration (46 variables). I will help you to sort this out.
Automatically confirmed in non-interactive mode

> MySQL

Automatically returned "mysql" in non-interactive mode
Automatically returned "my_database" in non-interactive mode
Automatically returned "root" in non-interactive mode

> Mailer

Automatically returned "mailhog" in non-interactive mode
Automatically returned "1025" in non-interactive mode
Automatically returned "" in non-interactive mode
Automatically returned "" in non-interactive mode

> RabbitMQ

Automatically returned "rabbitmq" in non-interactive mode
Automatically returned "5672" in non-interactive mode
Automatically returned "guest" in non-interactive mode
Automatically returned "guest" in non-interactive mode
Automatically returned "/" in non-interactive mode

> JWT

Automatically returned "foobar" in non-interactive mode

> Google API key

Automatically returned "MyGoogleAPIKey" in non-interactive mode
…
```