### PR TITLE
Fixing the boolean representation when using 1/0

### DIFF
--- a/features/fill-variables.feature
+++ b/features/fill-variables.feature
@@ -107,3 +107,21 @@ Feature:
     """
     A_BASE64_VALUE=abc123=
     """
+
+  Scenario: It displays correctly boolean with 1 and 0
+    Given the file ".env.dist" contains:
+    """
+    ## Something
+    MY_VARIABLE=0
+    """
+    And the file ".env" contains:
+    """
+    MY_VARIABLE=
+    """
+    When I run the companion with the following answers:
+      | Let's fix this? (y)        | y       |
+      | MY_VARIABLE ? (0)          | 0       |
+    And the file ".env" should contain:
+    """
+    MY_VARIABLE=0
+    """

--- a/src/Companienv/Interaction/AskVariableValues.php
+++ b/src/Companienv/Interaction/AskVariableValues.php
@@ -15,10 +15,10 @@ class AskVariableValues implements Extension
     public function getVariableValue(Companion $companion, Block $block, Variable $variable)
     {
         $definedVariablesHash = $companion->getDefinedVariablesHash();
-        $defaultValue = $definedVariablesHash[$variable->getName()] ?? $variable->getValue() ?: $variable->getValue();
+        $defaultValue = ($definedVariablesHash[$variable->getName()] ?? $variable->getValue()) ?: $variable->getValue();
         $question = sprintf('<comment>%s</comment> ? ', $variable->getName());
 
-        if ($defaultValue) {
+        if ($defaultValue !== '') {
             $question .= '('.$defaultValue.') ';
         }
 


### PR DESCRIPTION
Until now, if we had something like APP_DEBUG=0 in `.env.dist` file, it
was displayed like:

```
> Companienv\Composer\ScriptHandler::run
It looks like you are missing some configuration (1 variables). I will help you to sort this out.
Let's fix this? (y)

APP_DEBUG ?
```

So you have no idea what type of value you should place here (true? 1?
something else?). There's no problems with using "true" and "false",
however, since we can represent booleans with 1 and 0 as well, we need
to display it properly, as in:

```
> Companienv\Composer\ScriptHandler::run
It looks like you are missing some configuration (1 variables). I will help you to sort this out.
Let's fix this? (y)

APP_DEBUG ? (0)
```

So now you know you should place either "0" or "1" here.

The problem was actually just checking the if($variable) instead of
comparing using "!== ''", so it was considering the string "0" as false
and thus not display properly the default value after the question mark.

I've also added a test for checking this behaviour and added parenthesis
some lines up the "if" I've changed, for clarity of the null-coalesce/ternary
precedence.