### PR TITLE
Included a check when adding string to description

### DIFF
--- a/features/blocks.feature
+++ b/features/blocks.feature
@@ -43,6 +43,28 @@ Feature:
     MY_VARIABLE ? (default-value)
     """
 
+  Scenario: Displays the block description (multiline)
+    Given the file ".env.dist" contains:
+    """
+    ## Something
+    # With more details, so it's clearer to the user
+    # and even with extra lines
+    MY_VARIABLE=default-value
+    """
+    When I run the companion with the following answers:
+      | Let's fix this? (y)           | y        |
+      | MY_VARIABLE ? (default-value) | my-value |
+    Then the companion's output will look like that:
+    """
+    It looks like you are missing some configuration (1 variables). I will help you to sort this out.
+    Let's fix this? (y)
+
+    Something
+    With more details, so it's clearer to the user and even with extra lines
+
+    MY_VARIABLE ? (default-value)
+    """
+
   Scenario: I ignores the commented variables
     Given the file ".env.dist" contains:
     """

--- a/src/Companienv/DotEnv/Block.php
+++ b/src/Companienv/DotEnv/Block.php
@@ -23,7 +23,7 @@ class Block
 
     public function appendToDescription(string $string)
     {
-        $this->description .= $string;
+        $this->description .= ($this->description ? ' ' : '') . $string;
     }
 
     public function addVariable(Variable $variable)


### PR DESCRIPTION
When we have comments that span multiple lines, we display it inline and
thus we need a space between the lines, otherwise last word of line X will be
glued to first word of line X+1.

Instead of just adding space always when appending description, we need
to check if there's something there already, otherwise it's just an
empty string and our description would start with a blank space.

Solves: https://github.com/sroze/companienv/issues/17