### PR TITLE
Added custom dotenv variable value formatter

### DIFF
--- a/src/Companienv/Companion.php
+++ b/src/Companienv/Companion.php
@@ -4,10 +4,10 @@ namespace Companienv;
 
 use Companienv\DotEnv\Block;
 use Companienv\DotEnv\MissingVariable;
+use Companienv\DotEnv\ValueFormatter;
 use Companienv\DotEnv\Parser;
 use Companienv\IO\FileSystem\FileSystem;
 use Companienv\IO\Interaction;
-use Jackiedo\DotenvEditor\DotenvFormatter;
 use Jackiedo\DotenvEditor\DotenvWriter;
 
 class Companion
@@ -89,7 +89,7 @@ class Companion
 
         $variablesInFileHash = $this->getDefinedVariablesHash();
 
-        $writer = new DotenvWriter(new DotenvFormatter());
+        $writer = new DotenvWriter(new ValueFormatter());
         $fileContents = $this->fileSystem->getContents($this->envFileName);
         $writer->setBuffer($fileContents);
 

--- a/src/Companienv/DotEnv/ValueFormatter.php
+++ b/src/Companienv/DotEnv/ValueFormatter.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace Companienv\DotEnv;
+
+use Jackiedo\DotenvEditor\DotenvFormatter;
+
+class ValueFormatter extends DotenvFormatter
+{
+    public function formatValue($value, $forceQuotes = false)
+    {
+        if (!$forceQuotes) {
+            return $value;
+        }
+
+        $value = str_replace('\\', '\\\\', $value);
+        $value = str_replace('"', '\"', $value);
+        $value = "\"{$value}\"";
+
+        return $value;
+    }
+}


### PR DESCRIPTION
Jackiedo\DotenvEditor\DotenvFormatter::formatValue method makes assumption, that value must be escaped if slashes are present. It does not work properly, when type of env variable is JSON (https://symfony.com/blog/new-in-symfony-3-4-advanced-environment-variables), example:
```
#.env.dist
SPECIAL_IPS="[\"127.0.0.1/8\", \"172.17.0.1/16\"]"
```
we get 
```
#.env
SPECIAL_IPS="\"[\\\"127.0.0.1/8\\\", \\\"172.17.0.1/16\\\"]\""
```
Ideallly, helper generated .env file shoud be identical file to dist file, but without comments.