### PR TITLE
Allow Symfony 6 packages

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -16,9 +16,9 @@
   ],
   "require": {
     "php": ">=7.0",
-    "symfony/console": "~3.4 || ~4.0 || ~5.0",
-    "symfony/dotenv": "~3.4 || ~4.0 || ~5.0",
-    "symfony/process": "~3.4 || ~4.0 || ~5.0",
+    "symfony/console": "~3.4 || ~4.0 || ~5.0 || ~6.0",
+    "symfony/dotenv": "~3.4 || ~4.0 || ~5.0 || ~6.0",
+    "symfony/process": "~3.4 || ~4.0 || ~5.0 || ~6.0",
     "jackiedo/dotenv-editor": "~1.0"
   },
   "autoload": {


### PR DESCRIPTION
Please note that jackiedo/dotenv-editor triggers some deprecations in PHP 8.1 due to potentially passing null to strlen() & trim() which now raises a warning (for background, see https://php.watch/versions/8.1/internal-func-non-nullable-null-deprecation & https://wiki.php.net/rfc/deprecate_null_to_scalar_internal_arg). I don't believe this is a bug in companienv.